### PR TITLE
chore: create new release 6.0.0-eas.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [6.0.0-eas.1](https://github.com/nandorojo/expo-eas-semantic-release/compare/5.0.0...6.0.0-eas.1) (2021-07-08)
+
+
+### Other chores
+
+* create new release 5.0.0-eas.2 ([456828b](https://github.com/nandorojo/expo-eas-semantic-release/commit/456828b59d99913bb575143704d498ad36d6df94))
+
+
+* v6 IFF deleting branch matters. otherwise, no need to delete branches ([6349f68](https://github.com/nandorojo/expo-eas-semantic-release/commit/6349f68c3f3836847590c0c560116f3f178097d4))
+
 ## [5.0.0-eas.2](https://github.com/nandorojo/expo-eas-semantic-release/compare/5.0.0-eas.1...5.0.0-eas.2) (2021-07-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-semantic",
   "private": true,
-  "version": "5.0.0-eas.2",
+  "version": "6.0.0-eas.1",
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",


### PR DESCRIPTION
## [6.0.0-eas.1](https://github.com/nandorojo/expo-eas-semantic-release/compare/5.0.0...6.0.0-eas.1) (2021-07-08)

### Other chores

* create new release 5.0.0-eas.2 ([456828b](https://github.com/nandorojo/expo-eas-semantic-release/commit/456828b59d99913bb575143704d498ad36d6df94))

* v6 IFF deleting branch matters. otherwise, no need to delete branches ([6349f68](https://github.com/nandorojo/expo-eas-semantic-release/commit/6349f68c3f3836847590c0c560116f3f178097d4))