### PR TITLE
chore: create new release 6.0.1-eas.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### [6.0.1-eas.1](https://github.com/nandorojo/expo-eas-semantic-release/compare/6.0.0...6.0.1-eas.1) (2021-07-08)
+
+
+### Other chores
+
+* create new release 6.0.0-eas.1 ([c6d4a23](https://github.com/nandorojo/expo-eas-semantic-release/commit/c6d4a2312ee04787861c5c2cd44069e65d402a7a))
+
 ## [6.0.0-eas.1](https://github.com/nandorojo/expo-eas-semantic-release/compare/5.0.0...6.0.0-eas.1) (2021-07-08)
 
 ## [6.0.0](https://github.com/nandorojo/expo-eas-semantic-release/compare/5.0.0...6.0.0) (2021-07-08)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "eas-semantic",
   "private": true,
-  "version": "6.0.0-eas.1", 
+  "version": "6.0.1-eas.1",
   "devDependencies": {
     "@semantic-release/changelog": "^5.0.1",
     "@semantic-release/git": "^9.0.0",


### PR DESCRIPTION
### [6.0.1-eas.1](https://github.com/nandorojo/expo-eas-semantic-release/compare/6.0.0...6.0.1-eas.1) (2021-07-08)

### Other chores

* create new release 6.0.0-eas.1 ([c6d4a23](https://github.com/nandorojo/expo-eas-semantic-release/commit/c6d4a2312ee04787861c5c2cd44069e65d402a7a))